### PR TITLE
fix: correct root-hints path and healthcheck command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ EXPOSE 53/udp
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD drill @127.0.0.1 cloudflare.com || exit 1
+    CMD dig @127.0.0.1 cloudflare.com +short || exit 1
 
 # Run Unbound in foreground
 CMD ["unbound", "-d", "-c", "/opt/unbound/etc/unbound/unbound.conf"]

--- a/unbound.conf
+++ b/unbound.conf
@@ -75,4 +75,4 @@ server:
     log-queries: no
     
     # Root hints for DNS resolution
-    root-hints: "/usr/share/dns-root-hints/root.hints"
+    root-hints: "/usr/share/dns-root-hints/named.root"


### PR DESCRIPTION
- Fix root-hints path from root.hints to named.root (actual file location in Alpine's dns-root-hints package)
- Update healthcheck from drill to dig (drill not available in Alpine's bind-tools package)

This resolves the container exit issue where unbound-checkconf was failing due to missing root-hints file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)