### PR TITLE
fix: enable git credentials for semantic-release to push tags and com…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
…mits

- Set persist-credentials: true in release.yml to allow semantic-release to push tags and CHANGELOG commits
- Add required permissions (contents: write, issues: write, pull-requests: write) to ci.yml workflow
- Fixes EGITNOPERMISSION error where github-actions[bot] was denied push access
- Fixes "Resource not accessible by integration" error for issue creation

Generated with [Claude Code](https://claude.com/claude-code)