### PR TITLE
fix: add conventional-changelog-conventionalcommits dependency to rel…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,8 @@ jobs:
             @semantic-release/release-notes-generator \
             @semantic-release/git \
             @semantic-release/changelog \
-            @semantic-release/github
+            @semantic-release/github \
+            conventional-changelog-conventionalcommits
 
       - name: Semantic Release
         id: semantic


### PR DESCRIPTION
…ease workflow

- Install conventional-changelog-conventionalcommits package required by conventionalcommits preset
- Fixes MODULE_NOT_FOUND error: Cannot find module 'conventional-changelog-conventionalcommits'
- This package is needed when using preset: "conventionalcommits" in .releaserc.json

Generated with [Claude Code](https://claude.com/claude-code)