### PR TITLE
fix: use semantic-release-action to enable Docker build after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ jobs:
     name: Semantic Release
     runs-on: ubuntu-latest
     outputs:
-      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
-      new_release_version: ${{ steps.semantic.outputs.new_release_version }}
+      new_release_published: ${{ steps.semantic.outputs.new-release-published }}
+      new_release_version: ${{ steps.semantic.outputs.new-release-version }}
 
     steps:
       - name: Checkout repository
@@ -28,27 +28,14 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 'lts/*'
-
-      - name: Install dependencies
-        run: |
-          npm install -g \
-            semantic-release \
-            @semantic-release/commit-analyzer \
-            @semantic-release/release-notes-generator \
-            @semantic-release/git \
-            @semantic-release/changelog \
-            @semantic-release/github \
-            conventional-changelog-conventionalcommits
-
       - name: Semantic Release
         id: semantic
+        uses: codfish/semantic-release-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+        with:
+          additional-packages: |
+            ['@semantic-release/git', '@semantic-release/changelog', 'conventional-changelog-conventionalcommits']
 
   build-and-push:
     name: Build and Push Docker Image


### PR DESCRIPTION
- Replace manual npx semantic-release with codfish/semantic-release-action@v3
- This action properly sets GitHub Actions outputs (new-release-published, new-release-version)
- Fixes issue where build-and-push job never runs because outputs were undefined
- Removed manual Node.js setup and npm install steps (handled by action)
- Updated output references to use hyphenated format (new-release-published)

The action automatically installs semantic-release and specified additional packages, then exposes outputs that can be used by downstream jobs.

Generated with [Claude Code](https://claude.com/claude-code)